### PR TITLE
Fixes: CTRL+Click, Href rel path, devmode, duplicated code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 	<groupId>de.knightsoft-net</groupId>
 	<artifactId>gwt-pushstate</artifactId>
 	<packaging>jar</packaging>
-	<version>2.0.0.7</version>
+	<version>2.0.0.7.1</version>
 	<name>GWT pushState</name>
 	<description>
      gwt-pushstate implements easy to use HTML5 pushState support for GWT.

--- a/src/main/java/com/wallissoftware/pushstate/client/PushStateHistorian.java
+++ b/src/main/java/com/wallissoftware/pushstate/client/PushStateHistorian.java
@@ -52,6 +52,10 @@ public class PushStateHistorian implements Historian, HasValueChangeHandlers<Str
     "You must set relative path before calling any history method";
     PushStateHistorian.relativePath = prelativePath;
   }
+  
+  public static String getRelativePath() {
+    return relativePath;
+  }
 
   @Override
   public void fireEvent(final GwtEvent<?> pevent) {

--- a/src/main/java/com/wallissoftware/pushstate/client/PushStateHistorianImpl.java
+++ b/src/main/java/com/wallissoftware/pushstate/client/PushStateHistorianImpl.java
@@ -62,15 +62,15 @@ public class PushStateHistorianImpl implements Historian, HasValueChangeHandlers
    * @param preplaceState repace state
    */
   public void newItem(final String ptoken, final boolean pissueEvent, final boolean preplaceState) {
-    if (this.setToken(ptoken)) {
-      if (preplaceState) {
-        PushStateHistorianImpl.replaceState(this.relativePath, this.getToken());
-      } else {
-        PushStateHistorianImpl.pushState(this.relativePath, this.getToken());
-      }
-
-      if (pissueEvent) {
-        ValueChangeEvent.fire(this, this.getToken());
+    if (pissueEvent) {
+      ValueChangeEvent.fire(this, ptoken);
+    } else {
+      if (this.setToken(ptoken)) {
+        if (preplaceState) {
+          PushStateHistorianImpl.replaceState(this.relativePath, token);
+        } else {
+          PushStateHistorianImpl.pushState(this.relativePath, token);
+        }
       }
     }
   }
@@ -103,9 +103,7 @@ public class PushStateHistorianImpl implements Historian, HasValueChangeHandlers
 
   private final void initToken() {
     final String token = Window.Location.getPath() + Window.Location.getQueryString();
-
     this.setToken(token);
-    PushStateHistorianImpl.replaceState(this.relativePath, this.getToken());
   }
 
   private String stripStartSlash(final String pinput) {

--- a/src/main/java/com/wallissoftware/pushstate/client/ui/CodeServerParameterHelper.java
+++ b/src/main/java/com/wallissoftware/pushstate/client/ui/CodeServerParameterHelper.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2012 Johannes Barop
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.wallissoftware.pushstate.client.ui;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.user.client.Window;
+
+/**
+ * Utility class with methods to extract and add the <code>gwt.codesvr</code> to the URL.
+ * 
+ * <p>
+ * This is needed so that we not leave the development mode after pushing a history state.
+ * </p>
+ * 
+ * @author <a href="mailto:jb@barop.de">Johannes Barop</a>
+ * 
+ */
+final class CodeServerParameterHelper {
+
+  /**
+   * Hidden constructor as this class is not meant to be instantiated.
+   */
+  private CodeServerParameterHelper() {
+  }
+
+  /**
+   * Append the <code>gwt.codesvr</code> parameter to the token when needed.
+   */
+  public static String append(final String token) {
+    String result = token;
+
+    /*
+     * This gets compiled out in production mode!
+     */
+    if (!GWT.isProdMode() && GWT.isClient()) {
+      String gwtCodesvr = Window.Location.getParameter("gwt.codesvr");
+      if (gwtCodesvr != null) {
+        if (token.contains("?")) {
+          result += "&";
+        } else {
+          result += "?";
+        }
+        result += "gwt.codesvr=" + gwtCodesvr;
+      }
+    }
+
+    return result;
+  }
+
+}

--- a/src/main/java/com/wallissoftware/pushstate/client/ui/HyperlinkPushStateDelegate.java
+++ b/src/main/java/com/wallissoftware/pushstate/client/ui/HyperlinkPushStateDelegate.java
@@ -1,0 +1,69 @@
+package com.wallissoftware.pushstate.client.ui;
+
+import com.google.gwt.core.shared.GWT;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.event.dom.client.DomEvent;
+import com.google.gwt.place.shared.PlaceHistoryHandler.Historian;
+import com.google.gwt.user.client.DOM;
+import com.google.gwt.user.client.Event;
+import com.google.gwt.user.client.ui.Hyperlink;
+import com.wallissoftware.pushstate.client.PushStateHistorian;
+/**
+ * Common logic for {@link HyperlinkPushState} and {@link InlineHyperlinkPushState}. 
+ * 
+ * @author Daniel Hari
+ *
+ */
+class HyperlinkPushStateDelegate {
+
+  private static final Historian HISTORIAN = GWT.create(Historian.class);
+
+  private String targetHistoryToken;
+
+  private Hyperlink target;
+
+  HyperlinkPushStateDelegate(Hyperlink hyperlink) {
+    this.target = hyperlink;
+  }
+
+  public void setTargetHistoryToken(String ptargetHistoryToken) {
+    assert ptargetHistoryToken != null : "New history item cannot be null!";
+
+    this.targetHistoryToken = CodeServerParameterHelper.append(ptargetHistoryToken);
+
+    final String href = PushStateHistorian.getRelativePath() + ensureHasRoot(this.targetHistoryToken);
+    ((Element) target.getElement().getChild(0)).setPropertyString("href", href);
+  }
+
+  private String ensureHasRoot(final String ptargetHistoryToken) {
+    return (ptargetHistoryToken.length() > 0 && ptargetHistoryToken.charAt(0) == '/') ? ptargetHistoryToken
+        : "/" + ptargetHistoryToken;
+  }
+
+  public String getTargetHistoryToken() {
+    return targetHistoryToken;
+  }
+
+  public void onBrowserEvent(Event pevent) {
+    switch (DOM.eventGetType(pevent)) {
+    case Event.ONMOUSEOVER:
+    case Event.ONMOUSEOUT:
+      // Only fire the mouse over event if it's coming from outside this widget.
+      // Only fire the mouse out event if it's leaving this widget.
+      final Element related = pevent.getRelatedEventTarget().cast();
+      if (related != null && target.getElement().isOrHasChild(related)) {
+        return;
+      }
+      break;
+    default:
+      break;
+    }
+    DomEvent.fireNativeEvent(pevent, target, target.getElement());
+    if (DOM.eventGetType(pevent) == Event.ONCLICK && !pevent.getCtrlKey()) {
+      HyperlinkPushStateDelegate.HISTORIAN.newItem(this.getTargetHistoryToken(), true);
+      pevent.preventDefault();
+    }
+
+  }
+
+}

--- a/src/main/java/com/wallissoftware/pushstate/client/ui/InlineHyperlinkPushState.java
+++ b/src/main/java/com/wallissoftware/pushstate/client/ui/InlineHyperlinkPushState.java
@@ -14,11 +14,7 @@
 
 package com.wallissoftware.pushstate.client.ui;
 
-import com.google.gwt.core.shared.GWT;
-import com.google.gwt.dom.client.Element;
-import com.google.gwt.event.dom.client.DomEvent;
 import com.google.gwt.place.shared.PlaceHistoryHandler.Historian;
-import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.ui.InlineHyperlink;
 
@@ -40,60 +36,44 @@ import com.google.gwt.user.client.ui.InlineHyperlink;
  */
 public class InlineHyperlinkPushState extends InlineHyperlink {
 
-  private String targetHistoryToken;
-
-  private static final Historian HISTORIAN = GWT.create(Historian.class);
+  private HyperlinkPushStateDelegate delegate;
 
   /**
    * Calls {@link InlineHyperlink#InlineHyperlink(String, String)}.
    */
   public InlineHyperlinkPushState(final String ptext, final String ptargetHistoryToken) {
     super(ptext, ptargetHistoryToken);
+    ensureDelegate();
   }
 
   /**
-   * No arg constructor, calls {@link InlineHyperlink#InlineHyperlink()}.  
+   * No arg constructor, calls {@link InlineHyperlink#InlineHyperlink()}.
    */
   public InlineHyperlinkPushState() {
     super();
+    ensureDelegate();
   }
 
+  private void ensureDelegate() {
+    if(delegate == null)
+      delegate = new HyperlinkPushStateDelegate(this);
+  }
+  
   @Override
-  public void setTargetHistoryToken(final String ptargetHistoryToken) {
-    assert ptargetHistoryToken != null : "New history item cannot be null!";
-
-    this.targetHistoryToken = ptargetHistoryToken;
-
-    final String href = (ptargetHistoryToken.length() > 0 && ptargetHistoryToken.charAt(0) == '/')
-        ? ptargetHistoryToken : "/" + ptargetHistoryToken;
-    ((Element) this.getElement().getChild(0)).setPropertyString("href", href);
+  public void setTargetHistoryToken(String ptargetHistoryToken) {
+    ensureDelegate();
+    delegate.setTargetHistoryToken(ptargetHistoryToken);
   }
 
+  
   @Override
   public String getTargetHistoryToken() {
-    return this.targetHistoryToken;
+    return delegate.getTargetHistoryToken();
   }
 
   @Override
-  public void onBrowserEvent(final Event event) {
-    switch (DOM.eventGetType(event)) {
-      case Event.ONMOUSEOVER:
-      case Event.ONMOUSEOUT:
-        // Only fire the mouse over event if it's coming from outside this widget.
-        // Only fire the mouse out event if it's leaving this widget.
-        final Element related = event.getRelatedEventTarget().cast();
-        if (related != null && this.getElement().isOrHasChild(related)) {
-          return;
-        }
-        break;
-      default:
-        break;
-    }
-    DomEvent.fireNativeEvent(event, this, this.getElement());
-    if (DOM.eventGetType(event) == Event.ONCLICK) {
-      InlineHyperlinkPushState.HISTORIAN.newItem(this.getTargetHistoryToken(), true);
-      event.preventDefault();
-    }
+  public void onBrowserEvent(final Event pevent) {
+    delegate.onBrowserEvent(pevent);
   }
 
 }


### PR DESCRIPTION
Hi! 
Could you cross-check these fixes ? Thanks!

```
- Fixed CTRL+Click functionality for PushStateHyperlinks
- Fixed relative path in href elements of PushStateHyperlinks
- Re-added GWT classic devmode param suppport.
- Fixed event handling in PushStateHistorianImpl
- Extracted duplicated code from Hyperlink classes.
- + gitkeep for test/java folder
```
